### PR TITLE
Update plugin to support newer versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,14 +2,10 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "vmfloaty", "0.7.1"
+gem "vmfloaty", "0.8.2"
 
 group :development do
   gem "vagrant", git: "https://github.com/mitchellh/vagrant.git"
   gem "rspec"
   gem "rake"
-end
-
-group :plugins do
-  gem "vagrant-vmpooler", path: "."
 end

--- a/lib/vagrant-vmpooler/action/create_server.rb
+++ b/lib/vagrant-vmpooler/action/create_server.rb
@@ -70,7 +70,7 @@ module VagrantPlugins
           tags['machine-name'] = machine_name
 
           begin
-            response_body = Pooler.modify(verbose, url, server_name, token, nil, tags)
+            response_body = Pooler.modify(verbose, url, server_name, token, tags: tags)
             if response_body['ok'] == false
               env[:ui].warn(I18n.t("vagrant_vmpooler.errors.failed_tag"))
             end
@@ -82,7 +82,7 @@ module VagrantPlugins
 
           if ttl
             begin
-              response_body = Pooler.modify(verbose, url, server_name, token, ttl, nil)
+              response_body = Pooler.modify(verbose, url, server_name, token, lifetime: ttl)
               if response_body['ok'] == false
                 env[:ui].warn(I18n.t("vagrant_vmpooler.errors.failed_ttl"))
               end

--- a/lib/vagrant-vmpooler/action/read_ssh_info.rb
+++ b/lib/vagrant-vmpooler/action/read_ssh_info.rb
@@ -41,8 +41,9 @@ module VagrantPlugins
               username = 'root'
             end
 
+            host = server[id]['domain'].nil? ? id : "#{id}.#{server[id]['domain']}"
             ssh_info = {
-              :host => id,
+              :host => host,
               :username => username,
               :password => password
             }

--- a/lib/vagrant-vmpooler/plugin.rb
+++ b/lib/vagrant-vmpooler/plugin.rb
@@ -18,7 +18,7 @@ module VagrantPlugins
         Config
       end
 
-      provider(:vmpooler, parallel:true) do
+      provider(:vmpooler, parallel: true, box_optional: true) do
         Vmpooler.init_i18n
         Vmpooler.init_logging
 

--- a/vagrant-vmpooler.gemspec
+++ b/vagrant-vmpooler.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.summary       = "Enables Vagrant to manage machines in vmpooler."
   s.description   = "Enables Vagrant to manage machines in vmpooler."
 
-  s.add_runtime_dependency "vmfloaty", ">= 0.6.0"
+  s.add_runtime_dependency "vmfloaty", ">= 0.8.0"
 
   s.add_development_dependency "rspec-its"
 


### PR DESCRIPTION
I just stumbled across this plugin and figured it would be a good use case for some things I am working on. The plugin works great, and just needed a few small changes to work with newer versions of vmfloaty. 

This PR adds a few items, sorry for adding it all into one. 

1. Updates the code to use vmfloaty 0.8.2
1. Removes the dummy box requirement for Vagrant 1.6.0+
1. Uses the FQDN in the ssh_info if the domain is available
